### PR TITLE
Show latest message first

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.DS_Store
+node_modules
+.idea
+.vscode/*
+.vs/*

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -24,10 +24,10 @@ export class AppController {
   @Render('list')
   async list() {
     return {
-      messages: this.messages,
+      messages: this.messages.reverse(),
     };
   }
-  
+
   @UseGuards(new BasicAuthStrategy())
   @Get('details/:messageId')
   @Render('details')
@@ -54,8 +54,8 @@ export class AppController {
           'to': query.to,
           'message-id': Math.round(Math.random() * 10000),
           'status': '0',
-        }
-      ]
-    }
+        },
+      ],
+    };
   }
 }


### PR DESCRIPTION
#### What does this PR do? (please provide any background)
This PR changes the order messages appear in. For now, the latest message is the one at the bottom of the queue. Once a lot of messages get sent to Nexmock, this will become an issue, because we do not want to have to scroll down every time to get to the latest message.
This PR puts the latest message at the top of the page.

Also added a .gitignore, to guard against people that fork the repo and forget about ignoring the `node_modules` when pushing.
#### How can this be manually tested?
- Send a few messages to Nexmock
- See that the latest message is always on top
- [ ] AAReviewer, I checked those steps make sense

#### Any tech debt?
The TSLint config seems a bit annoying, forced me to add commas, semicolons, and to remove trailing whitespaces here and there. Might be worth looking into it?

#### What gif best describes how you feel about this work?

![](https://media.giphy.com/media/xUOrvYy2eOjKXmNa9O/giphy.gif)
