### PR TITLE
Fix message sorting by timestamp

### DIFF
--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -24,7 +24,7 @@ export class AppController {
   @Render('list')
   async list() {
     return {
-      messages: this.messages.reverse(),
+      messages: this.messages.sort((msgA, msgB) => msgB.timestamp.localeCompare(msgA.timestamp)),
     };
   }
 

--- a/src/models/message.ts
+++ b/src/models/message.ts
@@ -1,3 +1,13 @@
 export default class SmsMessage {
-    constructor(private to: string, private from: string, private text: string, private timestamp: string) {}
-  };
+    timestamp: string;
+    text: string;
+    from: string;
+    to: string;
+
+    constructor(to: string, from: string, text: string, timestamp: string) {
+        this.timestamp = timestamp;
+        this.text = text;
+        this.from = from;
+        this.to = to;
+    }
+  }


### PR DESCRIPTION
#### What does this PR do? (please provide any background)
This PR fixes [this one](https://github.com/birdiecare/nexmock/pull/1), that was a poor attempt at sorting messages by timestamp. This should work better, to properly sort them!
#### How can this be manually tested?
- Send a few messages to Nexmock
- See that the latest message is always on top
- Refresh, send more messages, see that everything is still fine
- [ ] AAReviewer, I checked those steps make sense

#### Any tech debt?
X
#### What gif best describes how you feel about this work?

![](https://media.giphy.com/media/2IEl7CVs4LVvi/giphy.gif)
