### PR TITLE
fix basic auth

### DIFF
--- a/src/security/basicGuard.ts
+++ b/src/security/basicGuard.ts
@@ -44,13 +44,13 @@ export class BasicAuthStrategy implements CanActivate {
       return requestAuthentication(response);
     }
 
-    const username = credentials[0];
-    const password = credentials[1];
-    if (!username || !password) {
+    const providedUsername = credentials[0];
+    const providedPassword = credentials[1];
+    if (!providedUsername || !providedPassword) {
       return requestAuthentication(response);
     }
 
-    if (username === username && password === password) {
+    if (providedUsername === username && providedPassword === password) {
       return true;
     }
 


### PR DESCRIPTION
the `username` and `password` variables are defined at the global scope, and were redefined in the authentication function

this PR makes sure we don't do a `true === true`-type comparison when authenticating